### PR TITLE
Add range check for --dy CLI option

### DIFF
--- a/OPL480pCheatGen.py
+++ b/OPL480pCheatGen.py
@@ -400,8 +400,11 @@ if __name__ == '__main__':
     p.add_argument('--dy', dest='dy', type=int, help='Override GS DY value')
     if len(sys.argv) == 1:
         p.print_help()
-        sys.exit(0)  
+        sys.exit(0)
     args = p.parse_args()
+    if args.dy is not None and not (-100 <= args.dy <= 100):
+        print("Error: --dy must be between -100 and 100.")
+        sys.exit(1)
     print(f"[INFO] OPL480pCheatGen starting on {args.input}")
 
     if args.input.lower().endswith('.iso'):


### PR DESCRIPTION
## Summary
- validate CLI `--dy` argument falls within -100..100 range

## Testing
- `python OPL480pCheatGen.py --help`
- `python OPL480pCheatGen.py /tmp/foo --dy 200`