### PR TITLE
Add manual aggressive patch support

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,6 +65,8 @@ OPL480pCheatGen.exe "F:\RetroBat\roms\ps2\Game.iso" --preview-only --force-240p
 --force-240p          # Use 240p instead of 480p
 --dy 51               # Override vertical offset (DY)
 --mastercode "CODE"   # Manually override mastercode
+--inject-hook ADDR    # Manually specify hook address for aggressive patch
+--inject-handler ADDR # Manually specify handler address for aggressive patch
 ```
 
 ---


### PR DESCRIPTION
## Summary
- extend aggressive display patch search to handle `daddiu`
- add manual injection capability for aggressive patches
- expose `--inject-hook` and `--inject-handler` options in CLI
- document new CLI flags

## Testing
- `python -m py_compile OPL480pCheatGen.py`
- `python OPL480pCheatGen.py -h`

------
https://chatgpt.com/codex/tasks/task_e_684351f5fab0832e8bc91d661c78397f