### PR TITLE
Use package version constant

### DIFF
--- a/OPL480pCheatGenGUI.py
+++ b/OPL480pCheatGenGUI.py
@@ -6,10 +6,14 @@ import threading
 import re
 import sys
 
+from opl480pcheatgen import __version__
+
 class OPLCheatGUI:
     def __init__(self, root):
         self.root = root
-        root.title("OPL480pCheatGen — 480p/240p Cheat Generator v1.1.0 — © 2025 ArcanBytes | tiempoinfinito.com")
+        root.title(
+            f"OPL480pCheatGen — 480p/240p Cheat Generator v{__version__} — © 2025 ArcanBytes | tiempoinfinito.com"
+        )
         self.current_cht_text = ""
         self.current_cht_filename = None
 

--- a/build.py
+++ b/build.py
@@ -3,6 +3,8 @@ import shutil
 import zipfile
 import PyInstaller.__main__
 
+from opl480pcheatgen import __version__
+
 def clean():
     for folder in ["build", "dist", "__pycache__"]:
         if os.path.exists(folder):
@@ -32,7 +34,8 @@ def build_exe(entry_script, name, data_files=[], icon=None, is_gui=False):
 
 def package_release():
     os.makedirs("release", exist_ok=True)
-    with zipfile.ZipFile("release/OPL480pCheatGen_v1.1.0.zip", 'w') as z:
+    zip_name = f"OPL480pCheatGen_v{__version__}.zip"
+    with zipfile.ZipFile(os.path.join("release", zip_name), 'w') as z:
         z.write('dist/OPL480pCheatGenGUI.exe', arcname='OPL480pCheatGenGUI.exe')
         z.write('dist/OPL480pCheatGen.exe', arcname='OPL480pCheatGen.exe')
         z.write('dist/mastercodes.json', arcname='mastercodes.json')
@@ -64,5 +67,5 @@ if __name__ == "__main__":
     print("[INFO] Packaging release...")
     package_release()
 
-    print("[DONE] Release zip created in ./release: OPL480pCheatGen_v1.1.0.zip")
+    print(f"[DONE] Release zip created in ./release: OPL480pCheatGen_v{__version__}.zip")
     clean()

--- a/opl480pcheatgen/__init__.py
+++ b/opl480pcheatgen/__init__.py
@@ -1,3 +1,6 @@
 """Internal package for OPL480pCheatGen refactored modules."""
+
+__version__ = "1.1.0"
+
 import warnings
 warnings.filterwarnings("ignore", category=UserWarning, module="pkg_resources")

--- a/opl480pcheatgen/cli.py
+++ b/opl480pcheatgen/cli.py
@@ -4,6 +4,8 @@ import argparse
 import os
 import sys
 
+from . import __version__
+
 from .helpers import extract_from_iso, write_cht, format_cht_text
 from .patches import extract_patches
 
@@ -95,7 +97,7 @@ def main(argv: list[str] | None = None) -> int:
         print("Error: --dy must be between -100 and 100.")
         return 1
 
-    print(f"[INFO] OPL480pCheatGen starting on {args.input}")
+    print(f"[INFO] OPL480pCheatGen v{__version__} starting on {args.input}")
     if args.patchup:
         from .patcher import patch_iso, patch_elf
 


### PR DESCRIPTION
## Summary
- expose `__version__` inside the package
- refer to the version constant in the build script and GUI title
- report version on CLI start up

## Testing
- `pip install -r requirements-tests.txt`
- `pytest -q` *(fails: FileNotFoundError: .7z files missing)*

------
https://chatgpt.com/codex/tasks/task_e_6849ac1944b0832e9c5255f262069b2c